### PR TITLE
自定义Host

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,9 @@ THUMB_ON = True      # 是否启用缩略图
 
 CHECK = True      # 是否开启手机截屏判定
 
+ASCII_PROXY = ""   #ascii反代，如果不清楚作用请留空
+                   #目前已知一个的反代站： https://ascii2d.dihe.moe
+
 proxies={ 
                'http':'',
                'https':''

--- a/config.py
+++ b/config.py
@@ -16,8 +16,12 @@ THUMB_ON = True      # 是否启用缩略图
 
 CHECK = True      # 是否开启手机截屏判定
 
-ASCII_PROXY = ""   #ascii反代，如果不清楚作用请留空
-                   #目前已知一个的反代站： https://ascii2d.dihe.moe
+HOST_CUSTOM = {
+                  # 自定义Host，不使用留空即可
+                  # 格式示例：'https://ascii2d.net' , 'http://localhost:12345'   
+                  'SAUCENAO': '',
+                  'ASCII': ''
+              }
 
 proxies={ 
                'http':'',

--- a/image.py
+++ b/image.py
@@ -15,7 +15,7 @@ try:
 except:
     import json
 
-from .config import SAUCENAO_RESULT_NUM, ASCII_RESULT_NUM, THUMB_ON, proxies, ASCII_PROXY
+from .config import SAUCENAO_RESULT_NUM, ASCII_RESULT_NUM, THUMB_ON, proxies, HOST_CUSTOM
 
 logger = log.new_logger('image')
 
@@ -386,13 +386,14 @@ class SauceNAO():
         params['db'] = db
         params['numres'] = numres
         self.params = params
+        self.host = HOST_CUSTOM['SAUCENAO'] or 'https://saucenao.com'
         self.header = "————>saucenao<————"
 
 
     async def get_sauce(self, url):
         self.params['url'] = url
         logger.debug(f"Now starting get the SauceNAO data:{url}")
-        response = await aiorequests.get('https://saucenao.com/search.php', params=self.params, timeout=15, proxies=proxies)
+        response = await aiorequests.get(f'{self.host}/search.php', params=self.params, timeout=15, proxies=proxies)
         data = await response.json()
         
         return data
@@ -440,7 +441,7 @@ class SauceNAO():
 class ascii2d():
     def __init__(self, num=2):
         self.num = num
-        self.host = ASCII_PROXY or "https://ascii2d.net"
+        self.host = HOST_CUSTOM['ASCII'] or "https://ascii2d.net"
         self.header = "————>ascii2d<————"
 
 

--- a/image.py
+++ b/image.py
@@ -15,7 +15,7 @@ try:
 except:
     import json
 
-from .config import SAUCENAO_RESULT_NUM, ASCII_RESULT_NUM, THUMB_ON, proxies
+from .config import SAUCENAO_RESULT_NUM, ASCII_RESULT_NUM, THUMB_ON, proxies, ASCII_PROXY
 
 logger = log.new_logger('image')
 
@@ -440,6 +440,7 @@ class SauceNAO():
 class ascii2d():
     def __init__(self, num=2):
         self.num = num
+        self.host = ASCII_PROXY or "https://ascii2d.net"
         self.header = "————>ascii2d<————"
 
 
@@ -459,7 +460,7 @@ class ascii2d():
                 if not data.xpath('.//img[@loading="lazy"]/@src'):
                     continue
                 thumb_url =  data.xpath('.//img[@loading="lazy"]/@src')[0].strip()
-                thumb_url =  f"https://ascii2d.net{thumb_url}"
+                thumb_url =  f"{self.host}{thumb_url}"
 
                 if not data.xpath('.//div[@class="detail-box gray-link"]/h6'):
                     data2=data.xpath('.//div[@class="external"]')[0] if data.xpath('.//div[@class="external"]') else data
@@ -509,8 +510,8 @@ class ascii2d():
     async def get_view(self, ascii2d) -> str:
         putline1 = ''
         putline2 = ''
-        url_index = "https://ascii2d.net/search/url/{}".format(ascii2d)
-        logger.debug("Now starting get the {}".format(url_index))
+        url_index = f"{self.host}/search/url/{ascii2d}"
+        logger.debug(f"Now starting get the {url_index}")
 
         try:
             html_index_data = await aiorequests.get(url_index, timeout=7, proxies=proxies)
@@ -525,7 +526,7 @@ class ascii2d():
         if neet_div:
 
             a_url_foot = neet_div[0].xpath('./span/a/@href')
-            url2 = "https://ascii2d.net{}".format(a_url_foot[1])
+            url2 = f"{self.host}{a_url_foot[1]}"
 
             color = await self.get_search_data('', data=html_index)
             bovw = await self.get_search_data(url2)


### PR DESCRIPTION
ascii经常会莫名其妙的查询失败
尤其阿里云上的bot必会失败
tx云上的偶尔会有一段时间抽风，过几天又好了
代理啥的都试过了都不行
后来听群里大佬提到可以反代解决
就在`config.py`里加了个`ASCII_PROXY`字段，如果留空就不生效，如果不为空就会替换`https://ascii2d.net`
我现在只知道一个地河佬的反代站`https://ascii2d.dihe.moe`
自己试了下阿里云上的bot可以正常查了
其他服务器偶尔抽风的情况还需要观察看看还会不会发生
