### PR TITLE
关于合并转发为空或错误的修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 - 22.01.10更新：适配新版图片CQcode，增加IGNORE_STAMP配置项，可在批量搜索中自动忽略subType不为0的图片（比如表情包）；用cloudscraper绕过ascii2d近期新增的cf认证
 
+- 22.03.28更新：修复合并转发错误的情况
+
 ## 特点  
 
 - 搜索SauceNao，在相似率过低时自动补充搜索ascii2d，相似率阈值可在config中调整。搜索结果显示数量可在config中调整。  

--- a/__init__.py
+++ b/__init__.py
@@ -270,8 +270,8 @@ async def chain_reply(bot, ev, chain, msg):
         data = {
             "type": "node",
             "data": {
-                    "name": str(NICKNAME[0]),
-                    "user_id": str(ev.self_id),
+                    "name": "小冰",
+                    "uin": "2854196306",
                     "content": str(msg)
             }
         }


### PR DESCRIPTION
默认是由bot号码转发，且使用的user_id字段，修改为uin并使用机器人小冰的号码转发解决错误。
可以改善[issue#4](https://github.com/pcrbot/picfinder_take/issues/4)。