### PR TITLE
修复一个卡顿的问题

### DIFF
--- a/image.py
+++ b/image.py
@@ -473,7 +473,7 @@ class ascii2d():
         else:
             # html_data = await aiorequests.get(url, timeout=15, proxies=proxies)
             # html = etree.HTML(await html_data.text)
-            html_data = self.scraper.get(url, timeout=15, proxies=proxies)
+            html_data = await aiorequests.run_sync_func(self.scraper.get, url, timeout=30, proxies=proxies)
             html = etree.HTML(html_data.text)
 
         all_data = html.xpath('//div[@class="row item-box"]')
@@ -542,7 +542,7 @@ class ascii2d():
         try:
             # html_index_data = await aiorequests.get(url_index, timeout=7, proxies=proxies)
             # html_index = etree.HTML(await html_index_data.text)
-            html_index_data = self.scraper.get(url_index, timeout=7, proxies=proxies)
+            html_index_data = await aiorequests.run_sync_func(self.scraper.get, url_index, timeout=7, proxies=proxies)
             html_index = etree.HTML(html_index_data.text)
         except Exception as e:
             print(format_exc())


### PR DESCRIPTION
在使用搜图时会卡顿，机器人无法响应其他命令，经检查由`cloudscraper`的同步执行引起。

修改：
把`cloudscraper`的使用改为了异步执行，直接使用`hoshino.aiorequests.run_sync_func()`。